### PR TITLE
Add internal needle to determine buffer length to truncate null bytes.

### DIFF
--- a/managed/BOFNET/BeaconConsoleWriter.cs
+++ b/managed/BOFNET/BeaconConsoleWriter.cs
@@ -32,12 +32,53 @@ namespace BOFNET {
 
             public override void Flush() {
                 base.Flush();
-
+                
                 if (Position > 0 && beaconCallbackWriter != null && ownerThread == Thread.CurrentThread) {
                     byte[] data = new byte[Position];
                     Seek(0, SeekOrigin.Begin);
                     Read(data, 0, data.Length);
-                    beaconCallbackWriter(OutputTypes.CALLBACK_OUTPUT_UTF8, data, data.Length);
+
+                    bool currentSeekHit = false;
+                    int stringIndex = 0;
+                    for (int index = 0; index < (data.Length - 2); index++)
+                    {
+                        if (currentSeekHit != true)
+                        {
+                            /*  
+                            *   Logical to check for sequential null values that go beyond our buffer length.
+                            *   Due to representation of null bytes in a UTF-8 callback, this can otherwise lead to "phantom" output which is the flushing of an allocated MemoryStream object.
+                            *
+                            *   As such, a "beacon operator" may receive multiple instances of "received output" from the callback.
+                            *   We implement our own needle here, assuming in both UTF-8 and UTF-16 arrays that sequential null bytes represent the termination of any string.
+                            *
+                            *   This prevents both pollution of output, and cleanliness of logs.
+                            *   All instances of the base class are still properly flushed at the end of our operations with a call the the base class' Dispose method.
+                            */
+                            if ((data[index] == (byte)0x00) && (data[index+1] == (byte)0x00))
+                            {
+                                stringIndex = index + 1;
+                                currentSeekHit = true;
+                            }
+                            else
+                            {
+                                stringIndex += 1;
+                            }
+                        }
+                    }
+                    
+                    if (currentSeekHit != true)
+                    {
+                        beaconCallbackWriter(OutputTypes.CALLBACK_OUTPUT_UTF8, data, data.Length);
+                    }
+                    else
+                    {
+                        if (stringIndex >= 2)
+                        {
+                            beaconCallbackWriter(OutputTypes.CALLBACK_OUTPUT_UTF8, data, stringIndex);
+                        }
+                    }
+
+                    // Regardless of output, seek to the beginning of the MemoryStream
                     Seek(0, SeekOrigin.Begin);
                 }                            
             }


### PR DESCRIPTION
This pull request implements an internal iteration of a read `MemoryStream` buffer, to check for sequential null bytes.

Due to the process of writing to the `UTF-8` callback, null characters are written to the stream.

From an operational perspective this has the effect of "phantom" output, where the `beacon` will acknowledge the callback and the operator will potentially have "blank" data.  In some cases, due to the allocation size, it has been known to cause issues with historical scrollback of `beacon` history.